### PR TITLE
Install Or Update Dependabot to support Docker and Gomods

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,37 +2,41 @@ version: 2
 enable-beta-ecosystems: true
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directory: /
   allow:
-  - dependency-type: "all"
+  - dependency-type: all
   schedule:
     interval: weekly
   groups:
     golang-dependencies:
       patterns:
-        - "github.com/golang*"
+      - github.com/golang*
     k8s-dependencies:
       patterns:
-        - "k8s.io*"
-        - "sigs.k8s.io*"
+      - k8s.io*
+      - sigs.k8s.io*
     github-dependencies:
       patterns:
-        - "*"
+      - '*'
       exclude-patterns:
-        - "github.com/golang*"
-        - "k8s.io*"
-        - "sigs.k8s.io*"
+      - github.com/golang*
+      - k8s.io*
+      - sigs.k8s.io*
   labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
+  - area/dependency
+  - release-note-none
+  - ok-to-test
   open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
+- package-ecosystem: github-actions
+  directory: /
   schedule:
-      interval: "daily"
+    interval: daily
   labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
+  - area/dependency
+  - release-note-none
+  - ok-to-test
   open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION

Enable Dependabot for Docker and GoMod if not already so.
Keeping K8s dependencies up-to-date. 

This PR is created by bot.

Signed-off-by: zhuxiaow@google.com
